### PR TITLE
Make `EventListenerPlugin` add bevy event

### DIFF
--- a/crates/bevy_eventlistener_core/src/lib.rs
+++ b/crates/bevy_eventlistener_core/src/lib.rs
@@ -20,7 +20,8 @@ impl<E> Default for EventListenerPlugin<E> {
 
 impl<E: EntityEvent> Plugin for EventListenerPlugin<E> {
     fn build(&self, app: &mut App) {
-        app.insert_resource(EventDispatcher::<E>::default())
+        app.add_event::<E>()
+            .insert_resource(EventDispatcher::<E>::default())
             .add_systems(
                 (
                     EventDispatcher::<E>::build.run_if(on_event::<E>()),

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -14,8 +14,8 @@ fn main() {
     App::new()
         .add_plugins(MinimalPlugins)
         .add_plugin(LogPlugin::default())
+        // Note that this plugin will add the `Attack` event to bevy:
         .add_plugin(EventListenerPlugin::<Attack>::default())
-        .add_event::<Attack>()
         .add_startup_system(setup)
         .add_system(attack_armor.run_if(on_timer(Duration::from_millis(200))))
         .run();

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -28,7 +28,6 @@ fn main() {
         .add_plugin(StressTestPlugin::<4>)
         // add an event that has no listeners in the hierarchy
         .add_plugin(EventListenerPlugin::<TestEvent<9>>::default())
-        .add_event::<TestEvent<9>>()
         .add_system(send_events::<9>)
         .run();
 }
@@ -37,7 +36,6 @@ struct StressTestPlugin<const N: usize>;
 impl<const N: usize> Plugin for StressTestPlugin<N> {
     fn build(&self, app: &mut App) {
         app.add_plugin(EventListenerPlugin::<TestEvent<N>>::default())
-            .add_event::<TestEvent<N>>()
             .add_startup_system(setup::<N>)
             .add_system(send_events::<N>);
     }


### PR DESCRIPTION
Small ergonomics improvement so users can add just the event listener plugin without also needing to `add_event<E>`.

This is non-breaking, as calling `add_event` multiple times has no effect.